### PR TITLE
ci: add new commands `nx serve-ssl` and `nx serve-ip`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ Thumbs.db
 
 # cypress
 **/cypress/**/screenshots/**
+
+.ssl

--- a/projects/demo/project.json
+++ b/projects/demo/project.json
@@ -58,12 +58,35 @@
         "serve": {
             "executor": "@angular-devkit/build-angular:dev-server",
             "options": {
-                "browserTarget": "demo:build"
+                "browserTarget": "demo:build",
+                "sslCert": ".ssl/localhost.pem",
+                "sslKey": ".ssl/localhost-key.pem"
             },
             "configurations": {
                 "production": {
                     "browserTarget": "demo:build:production"
                 }
+            }
+        },
+        "serve-ip": {
+            "builder": "@nrwl/workspace:run-commands",
+            "options": {
+                "command": "nx serve --open --host 0.0.0.0 --disable-host-check"
+            }
+        },
+        "serve-ssl": {
+            "builder": "@nrwl/workspace:run-commands",
+            "options": {
+                "parallel": false,
+                "commands": [
+                    "echo \"mkcert is a simple tool for making locally-trusted development certificates\"",
+                    "echo \"Read about installation and more: https://github.com/FiloSottile/mkcert\"",
+                    "echo ------",
+                    "mkcert -install",
+                    "mkdir -p .ssl",
+                    "mkcert -key-file .ssl/localhost-key.pem -cert-file .ssl/localhost.pem localhost 127.0.0.1 ::1",
+                    "nx serve --ssl"
+                ]
             }
         },
         "test": {


### PR DESCRIPTION
Run the following command to serve application with autogenerated ssl certificate:
```
nx serve-ssl
```

____
Run the following command to serve application with ability to open it from mobile device (computer and mobile should use the same wifi):
```
nx serve-ip
```

