### PR TITLE
ci(demo): fix base href for `nx serve`

### DIFF
--- a/projects/demo/project.json
+++ b/projects/demo/project.json
@@ -8,8 +8,6 @@
         "build": {
             "executor": "@angular-devkit/build-angular:browser",
             "options": {
-                "baseHref": "",
-                "deployUrl": "",
                 "outputPath": "dist/demo/browser",
                 "index": "projects/demo/src/index.html",
                 "main": "projects/demo/src/main.browser.ts",
@@ -51,9 +49,12 @@
                             "maximumError": "5mb"
                         }
                     ]
+                },
+                "development": {
+                    "baseHref": "/"
                 }
             },
-            "defaultConfiguration": ""
+            "defaultConfiguration": "production"
         },
         "serve": {
             "executor": "@angular-devkit/build-angular:dev-server",
@@ -65,8 +66,12 @@
             "configurations": {
                 "production": {
                     "browserTarget": "demo:build:production"
+                },
+                "development": {
+                    "browserTarget": "demo:build:development"
                 }
-            }
+            },
+            "defaultConfiguration": "development"
         },
         "serve-ip": {
             "builder": "@nrwl/workspace:run-commands",
@@ -111,9 +116,10 @@
                     "outputHashing": "media",
                     "sourceMap": false,
                     "optimization": true
-                }
+                },
+                "development": {}
             },
-            "defaultConfiguration": ""
+            "defaultConfiguration": "production"
         },
         "serve-ssr": {
             "executor": "@nguniversal/builders:ssr-dev-server",
@@ -125,8 +131,13 @@
                 "production": {
                     "browserTarget": "demo:build:production",
                     "serverTarget": "demo:server:production"
+                },
+                "development": {
+                    "serverTarget": "demo:server:development",
+                    "browserTarget": "demo:build:development"
                 }
-            }
+            },
+            "defaultConfiguration": "development"
         },
         "prerender": {
             "executor": "@nguniversal/builders:prerender",

--- a/projects/demo/src/index.html
+++ b/projects/demo/src/index.html
@@ -2,7 +2,6 @@
 <html>
     <head>
         <meta charset="utf-8" />
-        <base href="./" />
         <meta
             http-equiv="Content-Type"
             content="text/html; charset=utf-8"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
Run `nx serve`-command.

Go to `/lazy`-route.
It throws error:
<img width="1046" alt="Screenshot 2022-12-05 at 14 49 20" src="https://user-images.githubusercontent.com/35179038/205630351-8d256046-ea6c-4480-be15-cd4596b0e745.png">


## What is the new behavior?
No error
