### PR TITLE
ci: remove redundant `deployUrl`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 on:
   push:
     branches:
-      - broken-gh-pages
+      - main
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 on:
   push:
     branches:
-      - main
+      - broken-gh-pages
 
 jobs:
   deploy:

--- a/projects/demo/project.json
+++ b/projects/demo/project.json
@@ -9,7 +9,6 @@
             "executor": "@angular-devkit/build-angular:browser",
             "options": {
                 "baseHref": "/",
-                "deployUrl": "/",
                 "outputPath": "dist/demo/browser",
                 "index": "projects/demo/src/index.html",
                 "main": "projects/demo/src/main.browser.ts",


### PR DESCRIPTION
Fix after another fix https://github.com/Tinkoff/angular-open-source-starter/pull/66 :D