### PR TITLE
ci: script `getAllVersions` should always return array

### DIFF
--- a/scripts/helpers/get-all-versions.ts
+++ b/scripts/helpers/get-all-versions.ts
@@ -1,7 +1,9 @@
 import {execSync} from 'child_process';
 
 export function getAllVersions(name: string): string[] {
-    return JSON.parse(
+    const versions: string[] | string = JSON.parse(
         execSync(`npm view ${name} versions --json || echo "[]"`).toString(),
     );
+
+    return Array.isArray(versions) ? versions : [versions];
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
See https://github.com/Tinkoff/maskito/actions/runs/4183887175/jobs/7248819428

```
/home/runner/work/maskito/maskito/scripts/helpers/get-last-major-version.ts:2
    return Math.max(...versions.map(x => parseInt(x)), currentMajor);
                                ^
TypeError: versions.map is not a function
    at Object.getLastMajorVersion (/home/runner/work/maskito/maskito/scripts/helpers/get-last-major-version.ts:2:33)
    at makeTag (/home/runner/work/maskito/maskito/scripts/npm-publish.ts:37:[29](https://github.com/Tinkoff/maskito/actions/runs/4183887175/jobs/7248819428#step:5:30))
    at /home/runner/work/maskito/maskito/scripts/npm-publish.ts:27:17
    at Generator.next (<anonymous>)
    at fulfilled (/home/runner/work/maskito/maskito/node_modules/tslib/tslib.js:115:62)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
